### PR TITLE
Fix/combobox disabled option click

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1786,7 +1786,7 @@ function OptionFn<
     id,
     ref: optionRef,
     role: 'option',
-    tabIndex: disabled === true ? undefined : -1,
+    tabIndex: -1,
     'aria-disabled': disabled === true ? true : undefined,
     // According to the WAI-ARIA best practices, we should use aria-checked for
     // multi-select,but Voice-Over disagrees. So we use aria-checked instead for

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1728,6 +1728,12 @@ function OptionFn<
     if (disabled || data.virtual?.disabled(value)) return event.preventDefault()
     select()
 
+    if (data.mode === ValueMode.Single) {
+      requestAnimationFrame(() => actions.closeCombobox())
+    }
+  })
+
+  let handleFocus = useEvent(() => {
     // We want to make sure that we don't accidentally trigger the virtual keyboard.
     //
     // This would happen if the input is focused, the options are open, you select an option (which
@@ -1744,12 +1750,6 @@ function OptionFn<
       requestAnimationFrame(() => data.inputRef.current?.focus({ preventScroll: true }))
     }
 
-    if (data.mode === ValueMode.Single) {
-      requestAnimationFrame(() => actions.closeCombobox())
-    }
-  })
-
-  let handleFocus = useEvent(() => {
     if (disabled || data.virtual?.disabled(value)) {
       return actions.goToOption(Focus.Nothing)
     }

--- a/packages/@headlessui-react/src/test-utils/interactions.ts
+++ b/packages/@headlessui-react/src/test-utils/interactions.ts
@@ -252,7 +252,7 @@ export async function rawClick(
       if (!cancelled) {
         let next: HTMLElement | null = element as HTMLElement | null
         while (next !== null) {
-          if (next.matches(focusableSelector)) {
+          if (next.matches(focusableSelectorWithNegativeTabindex)) {
             next.focus()
             break
           }
@@ -463,9 +463,7 @@ function focusNext(event: Partial<KeyboardEvent>) {
   return innerFocusNext()
 }
 
-// Credit:
-//  - https://stackoverflow.com/a/30753870
-let focusableSelector = [
+let _focusableSelector = [
   '[contentEditable=true]',
   '[tabindex]',
   'a[href]',
@@ -476,6 +474,10 @@ let focusableSelector = [
   'select:not([disabled])',
   'textarea:not([disabled])',
 ]
+
+// Credit:
+//  - https://stackoverflow.com/a/30753870
+let focusableSelector = _focusableSelector
   .map(
     process.env.NODE_ENV === 'test'
       ? // TODO: Remove this once JSDOM fixes the issue where an element that is
@@ -483,6 +485,14 @@ let focusableSelector = [
         // in real browsers.
         (selector) => `${selector}:not([tabindex='-1']):not([style*='display: none'])`
       : (selector) => `${selector}:not([tabindex='-1'])`
+  )
+  .join(',')
+
+let focusableSelectorWithNegativeTabindex = _focusableSelector
+  .map(
+    process.env.NODE_ENV === 'test'
+      ? (selector) => `${selector}:not([style*='display: none'])`
+      : (selector) => selector
   )
   .join(',')
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -1461,6 +1461,12 @@ export let ComboboxOption = defineComponent({
       if (props.disabled || api.virtual.value?.disabled(props.value)) return event.preventDefault()
       api.selectOption(id)
 
+      if (api.mode.value === ValueMode.Single) {
+        requestAnimationFrame(() => api.closeCombobox())
+      }
+    }
+
+    function handleFocus() {
       // We want to make sure that we don't accidentally trigger the virtual keyboard.
       //
       // This would happen if the input is focused, the options are open, you select an option
@@ -1477,12 +1483,6 @@ export let ComboboxOption = defineComponent({
         requestAnimationFrame(() => dom(api.inputRef)?.focus({ preventScroll: true }))
       }
 
-      if (api.mode.value === ValueMode.Single) {
-        requestAnimationFrame(() => api.closeCombobox())
-      }
-    }
-
-    function handleFocus() {
       if (props.disabled || api.virtual.value?.disabled(props.value)) {
         return api.goToOption(Focus.Nothing)
       }

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -1519,7 +1519,7 @@ export let ComboboxOption = defineComponent({
         id,
         ref: internalOptionRef,
         role: 'option',
-        tabIndex: disabled === true ? undefined : -1,
+        tabIndex: -1,
         'aria-disabled': disabled === true ? true : undefined,
         // According to the WAI-ARIA best practices, we should use aria-checked for
         // multi-select,but Voice-Over disagrees. So we use aria-selected instead for

--- a/packages/@headlessui-vue/src/test-utils/interactions.ts
+++ b/packages/@headlessui-vue/src/test-utils/interactions.ts
@@ -243,7 +243,7 @@ export async function click(
       if (!cancelled) {
         let next: HTMLElement | null = element as HTMLElement | null
         while (next !== null) {
-          if (next.matches(focusableSelector)) {
+          if (next.matches(focusableSelectorWithNegativeTabindex)) {
             next.focus()
             break
           }
@@ -456,9 +456,7 @@ function focusNext(event: Partial<KeyboardEvent>) {
   return innerFocusNext()
 }
 
-// Credit:
-//  - https://stackoverflow.com/a/30753870
-let focusableSelector = [
+let _focusableSelector = [
   '[contentEditable=true]',
   '[tabindex]',
   'a[href]',
@@ -469,6 +467,10 @@ let focusableSelector = [
   'select:not([disabled])',
   'textarea:not([disabled])',
 ]
+
+// Credit:
+//  - https://stackoverflow.com/a/30753870
+let focusableSelector = _focusableSelector
   .map(
     process.env.NODE_ENV === 'test'
       ? // TODO: Remove this once JSDOM fixes the issue where an element that is
@@ -476,6 +478,14 @@ let focusableSelector = [
         // in real browsers.
         (selector) => `${selector}:not([tabindex='-1']):not([style*='display: none'])`
       : (selector) => `${selector}:not([tabindex='-1'])`
+  )
+  .join(',')
+
+let focusableSelectorWithNegativeTabindex = _focusableSelector
+  .map(
+    process.env.NODE_ENV === 'test'
+      ? (selector) => `${selector}:not([style*='display: none'])`
+      : (selector) => selector
   )
   .join(',')
 

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -218,16 +218,14 @@ function mergeProps(...listOfProps: Record<any, any>[]) {
     }
   }
 
-  // Do not attach any event handlers when there is a `disabled` or `aria-disabled` prop set.
+  // Ensure event listeners are not called if `disabled` or `aria-disabled` is true
   if (target.disabled || target['aria-disabled']) {
-    return Object.assign(
-      target,
-      // Set all event listeners that we collected to `undefined`. This is
-      // important because of the `cloneElement` from above, which merges the
-      // existing and new props, they don't just override therefore we have to
-      // explicitly nullify them.
-      Object.fromEntries(Object.keys(eventHandlers).map((eventName) => [eventName, undefined]))
-    )
+    for (let eventName in eventHandlers) {
+      // Prevent default events for `onClick`, `onMouseDown`, `onKeyDown`, etc.
+      if (/^(on(?:Click|Pointer|Mouse|Key)(?:Down|Up|Press)?)$/.test(eventName)) {
+        eventHandlers[eventName] = [(e: any) => e?.preventDefault?.()]
+      }
+    }
   }
 
   // Merge event handlers


### PR DESCRIPTION
Fixed an issue with the `Combobox` component where clicking a disabled `Combobox.Option` would take focus away from `Combobox.Input`.

[sample codesandbox](https://codesandbox.io/p/sandbox/headless-ui-combobox-with-disabled-option-sn2ktl?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clsy8bjzk00063b83mjysamyk%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clsy8bjzk00023b83gkf19q9s%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clsy8bjzk00033b837ly238uh%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clsy8bjzk00053b83xqc7dm95%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clsy8bjzk00023b83gkf19q9s%2522%253A%257B%2522id%2522%253A%2522clsy8bjzk00023b83gkf19q9s%2522%252C%2522tabs%2522%253A%255B%255D%257D%252C%2522clsy8bjzk00053b83xqc7dm95%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clsy8bjzk00043b83gw4rpglo%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clsy8bjzk00053b83xqc7dm95%2522%252C%2522activeTabId%2522%253A%2522clsy8bjzk00043b83gw4rpglo%2522%257D%252C%2522clsy8bjzk00033b837ly238uh%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clsy8bjzk00033b837ly238uh%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)